### PR TITLE
refactor(movies): backfill null values of name

### DIFF
--- a/db/migrations/20180529105552_backfill_movies_name.js
+++ b/db/migrations/20180529105552_backfill_movies_name.js
@@ -1,0 +1,9 @@
+'use strict';
+
+exports.up = (Knex) => {
+  return Knex.raw('UPDATE movies SET name = title WHERE name IS NULL');
+};
+
+exports.down = (Knex, Promise) => {
+  return Promise.resolve();
+};

--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -3,8 +3,7 @@
 const Movie = require('../../../models/movie');
 
 exports.create = (payload) => {
-  payload.name = payload.title;
-  payload.title = undefined;
-  return new Movie().save(payload)
+  const moviePayload = { name: payload.title, release_year: payload.release_year };
+  return new Movie().save(moviePayload)
   .then((movie) => new Movie({ id: movie.id }).fetch());
 };

--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -4,6 +4,7 @@ const Movie = require('../../../models/movie');
 
 exports.create = (payload) => {
   payload.name = payload.title;
+  payload.title = undefined;
   return new Movie().save(payload)
   .then((movie) => new Movie({ id: movie.id }).fetch());
 };

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -11,7 +11,7 @@ describe('movie controller', () => {
 
       return Controller.create(payload)
       .then((movie) => {
-        expect(movie.get('name')).to.eql(payload.name);
+        expect(movie.get('name')).to.eql(payload.title);
       });
     });
 

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -11,8 +11,7 @@ describe('movie controller', () => {
 
       return Controller.create(payload)
       .then((movie) => {
-        expect(movie.get('title')).to.eql(payload.title);
-        expect(movie.get('name')).to.eql(payload.title);
+        expect(movie.get('name')).to.eql(payload.name);
       });
     });
 


### PR DESCRIPTION
What: backfill null values of name with values from title
Why: make name not null so we can add the constraint
Details:
Wrote migration to backfill all null values of name
Stopped saving to the title column