### PR TITLE
refactor(movies): add not-null constraint to name and drop title

### DIFF
--- a/db/migrations/20180529132902_drop_title_from_movies.js
+++ b/db/migrations/20180529132902_drop_title_from_movies.js
@@ -1,0 +1,19 @@
+'use strict';
+
+exports.up = (Knex) => {
+  return Knex.schema.table('movies', (table) => {
+    table.dropColumn('title');
+  })
+  .then(() => {
+    return Knex.raw('ALTER TABLE movies ALTER COLUMN name SET NOT NULL');
+  });
+};
+
+exports.down = (Knex) => {
+  return Knex.schema.table('movies', (table) => {
+    table.text('title');
+  })
+  .then(() => {
+    return Knex.raw('ALTER TABLE movies ALTER COLUMN name DROP NOT NULL');
+  });
+};

--- a/lib/models/movie.js
+++ b/lib/models/movie.js
@@ -7,7 +7,7 @@ module.exports = Bookshelf.Model.extend({
   serialize: function () {
     return {
       id: this.get('id'),
-      title: this.get('title'),
+      title: this.get('name'),
       release_year: this.get('release_year'),
       object: 'movie'
     };

--- a/test/factories/movie.js
+++ b/test/factories/movie.js
@@ -4,6 +4,6 @@ const Factory = require('rosie').Factory;
 
 const MovieFactory = new Factory()
   .sequence('id', (i) => i.toString())
-  .attr('title', 'Title');
+  .attr('name', 'Name');
 
 module.exports = MovieFactory;

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -4,8 +4,8 @@ const Controller   = require('../../../../lib/plugins/features/movies/controller
 const Knex         = require('../../../../lib/libraries/knex');
 const MovieFactory = require('../../../../test/factories/movie');
 
-const movieOne = MovieFactory.build({ title: 'One', release_year: 2000 });
-const movieTwo = MovieFactory.build({ title: 'Two', release_year: 2010 });
+const movieOne = MovieFactory.build({ name: 'One', release_year: 2000 });
+const movieTwo = MovieFactory.build({ name: 'Two', release_year: 2010 });
 
 describe('movie controller', () => {
 

--- a/test/plugins/features/movies/index.test.js
+++ b/test/plugins/features/movies/index.test.js
@@ -4,8 +4,8 @@ const Knex         = require('../../../../lib/libraries/knex');
 const MovieFactory = require('../../../../test/factories/movie');
 const Movies       = require('../../../../lib/server');
 
-const movieOne = MovieFactory.build({ title: 'One', release_year: 2000 });
-const movieTwo = MovieFactory.build({ title: 'Two', release_year: 2010 });
+const movieOne = MovieFactory.build({ name: 'One', release_year: 2000 });
+const movieTwo = MovieFactory.build({ name: 'Two', release_year: 2010 });
 
 describe('movies integration', () => {
 


### PR DESCRIPTION
What: made `name` not-null and dropped `title` column
Why: final step to rename column with zero downtime
Details:
Added migration to add not-null constraint to `name` and drop `title` column
Changed test movies and movie serialize function to use `name`